### PR TITLE
Prefer https for vimeo API call

### DIFF
--- a/embetter.js
+++ b/embetter.js
@@ -198,7 +198,7 @@
     getData: function(mediaUrl, callback) {
       var videoId = mediaUrl.split('vimeo.com/')[1];
       window.reqwest({
-        url: 'http://vimeo.com/api/v2/video/'+ videoId +'.json',
+        url: 'https://vimeo.com/api/v2/video/'+ videoId +'.json',
         type: 'jsonp',
         error: function (err) {},
         success: function (data) {


### PR DESCRIPTION
Partially addresses #3, although it seems like there is an opportunity to make this change for all of the services. It's just a matter of making sure they're all cool with https.
